### PR TITLE
Customize PR comment title

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ _👉 See more examples in [`examples/README.md`](examples/README.md)_
 | `badge_branch` | ❌        | Branch where the badge will be committed (default: `badge-generator`)  |
 | `main_branch`  | ❌        | The main branch name (default: `main`)                                 |
 | `github_token` | ❌        | GitHub token (required for PR comments)                                |
+| `comment_title` | ❌       | Custom title for the PR comment (default: `Code Coverage Result`)      |
+
+### PR comment customization
+
+When `github_token` is provided, the action can comment the latest coverage result on the pull request. If you use the action multiple times in the same workflow, set `comment_title` to make each comment clearer.
+
+```yaml
+- name: Generate Vitest coverage badge
+  uses: ernanej/badge-generator@main
+  with:
+    name: '79.14%'
+    prefix: 'coverage'
+    path: 'badges/coverage.svg'
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    comment_title: 'Vitest Coverage Result'
+
+- name: Generate Cypress coverage badge
+  uses: ernanej/badge-generator@main
+  with:
+    name: '42.66%'
+    prefix: 'coverage'
+    path: 'badges/coverage-cypress.svg'
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    comment_title: 'Cypress Coverage Result'
+```
 
 ## 🛠️ Local Development
 

--- a/__tests__/github.test.js
+++ b/__tests__/github.test.js
@@ -67,6 +67,21 @@ describe('commentCoverageOnPR', () => {
     });
   });
 
+  it('should use a custom comment title when provided', async () => {
+    await commentCoverageOnPR({
+      token: 'fake-token',
+      coverage: '79%',
+      commentTitle: 'Cypress Coverage Result',
+    });
+
+    expect(mockCreateComment).toHaveBeenCalledWith({
+      owner: 'user',
+      repo: 'repo',
+      issue_number: 123,
+      body: expect.stringContaining('🛡️ **Cypress Coverage Result**'),
+    });
+  });
+
   it('should skip if no PR number is found', async () => {
     github.context.payload.pull_request = undefined;
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -64,6 +64,7 @@ describe('run()', () => {
         badge_branch: 'badge-generator',
         main_branch: 'main',
         github_token: 'fake-token',
+        comment_title: '',
       };
       return values[key];
     });
@@ -120,6 +121,48 @@ describe('run()', () => {
       'No open PR found for branch feature-branch. Skipping comment.'
     );
     expect(commentCoverageOnPR).not.toHaveBeenCalled();
+  });
+
+  it('should forward a custom comment title when provided', async () => {
+    core.getInput.mockImplementation((key) => {
+      const values = {
+        name: '95%',
+        prefix: 'coverage',
+        icon: 'jest',
+        color: 'green',
+        style: 'flat-square',
+        path: 'badges/coverage.svg',
+        labelColor: '',
+        logoColor: '',
+        link: '',
+        cacheSeconds: '',
+        badge_branch: 'badge-generator',
+        main_branch: 'main',
+        github_token: 'fake-token',
+        comment_title: 'Vitest Coverage Result',
+      };
+      return values[key];
+    });
+
+    github.context.ref = 'refs/heads/feature-branch';
+    github.context.eventName = 'push';
+
+    const mockList = jest.fn().mockResolvedValue({
+      data: [{ number: 42 }],
+    });
+
+    github.getOctokit.mockReturnValue({
+      rest: { pulls: { list: mockList } },
+    });
+
+    await run();
+
+    expect(commentCoverageOnPR).toHaveBeenCalledWith({
+      token: 'fake-token',
+      coverage: '95%',
+      prNumber: 42,
+      commentTitle: 'Vitest Coverage Result',
+    });
   });
 
   it('should skip if no token and not main', async () => {

--- a/action.schema.json
+++ b/action.schema.json
@@ -56,6 +56,21 @@
       "required": false,
       "default": ""
     },
+    "badge_branch": {
+      "description": "The branch where the badge should be committed (e.g. badge-generator).",
+      "required": false,
+      "default": "badge-generator"
+    },
+    "main_branch": {
+      "description": "The default branch of the repository (e.g. main).",
+      "required": false,
+      "default": "main"
+    },
+    "github_token": {
+      "description": "GitHub token to post comments on pull requests.",
+      "required": false,
+      "default": ""
+    },
     "comment_title": {
       "description": "Optional custom title for the pull request comment (e.g. 'Vitest Coverage Result').",
       "required": false,

--- a/action.schema.json
+++ b/action.schema.json
@@ -55,6 +55,11 @@
       "description": "Optional Shields.io cache duration (in seconds).",
       "required": false,
       "default": ""
+    },
+    "comment_title": {
+      "description": "Optional custom title for the pull request comment (e.g. 'Vitest Coverage Result').",
+      "required": false,
+      "default": ""
     }
   },
   "runs": {

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,11 @@ inputs:
     required: false
     default: ''
 
+  comment_title:
+    description: 'Optional custom title for the pull request comment (e.g. "Vitest Coverage Result").'
+    required: false
+    default: ''
+
 outputs: {}
 
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -36365,9 +36365,10 @@ const github = __nccwpck_require__(3228);
  * @param {string} options.token - GitHub token
  * @param {string} options.coverage - Coverage percentage string (e.g. "98.5%")
  * @param {number} [options.prNumber] - Pull request number (optional override)
+ * @param {string} [options.commentTitle] - Optional title for the PR comment
  * @returns {Promise<void>}
  */
-async function commentCoverageOnPR({ token, coverage, prNumber }) {
+async function commentCoverageOnPR({ token, coverage, prNumber, commentTitle }) {
   const context = github.context;
   const number = prNumber || context.payload.pull_request?.number;
 
@@ -36379,8 +36380,9 @@ async function commentCoverageOnPR({ token, coverage, prNumber }) {
   }
 
   const octokit = github.getOctokit(token);
+  const title = commentTitle || 'Code Coverage Result';
 
-  const body = `🛡️ **Code Coverage Result**
+  const body = `🛡️ **${title}**
 
 The latest CI run for this pull request reports a code coverage of \`${coverage}\`.`;
 
@@ -36426,6 +36428,7 @@ async function run() {
       badgeBranch: core.getInput('badge_branch') || 'badge-generator',
       mainBranch: core.getInput('main_branch') || 'main',
       githubToken: core.getInput('github_token'),
+      commentTitle: core.getInput('comment_title'),
     };
 
     const isPR = github.context.eventName === 'pull_request';
@@ -36455,11 +36458,17 @@ async function run() {
       if (pullRequests.length > 0) {
         const prNumber = pullRequests[0].number;
         core.info(`Found open PR #${prNumber} for branch ${currentBranch}. Commenting coverage...`);
-        await commentCoverageOnPR({
+        const commentOptions = {
           token: inputs.githubToken,
           coverage: inputs.name,
           prNumber,
-        });
+        };
+
+        if (inputs.commentTitle) {
+          commentOptions.commentTitle = inputs.commentTitle;
+        }
+
+        await commentCoverageOnPR(commentOptions);
       } else {
         core.info(`No open PR found for branch ${currentBranch}. Skipping comment.`);
       }

--- a/src/github.js
+++ b/src/github.js
@@ -8,9 +8,10 @@ const github = require('@actions/github');
  * @param {string} options.token - GitHub token
  * @param {string} options.coverage - Coverage percentage string (e.g. "98.5%")
  * @param {number} [options.prNumber] - Pull request number (optional override)
+ * @param {string} [options.commentTitle] - Optional title for the PR comment
  * @returns {Promise<void>}
  */
-async function commentCoverageOnPR({ token, coverage, prNumber }) {
+async function commentCoverageOnPR({ token, coverage, prNumber, commentTitle }) {
   const context = github.context;
   const number = prNumber || context.payload.pull_request?.number;
 
@@ -22,8 +23,9 @@ async function commentCoverageOnPR({ token, coverage, prNumber }) {
   }
 
   const octokit = github.getOctokit(token);
+  const title = commentTitle || 'Code Coverage Result';
 
-  const body = `🛡️ **Code Coverage Result**
+  const body = `🛡️ **${title}**
 
 The latest CI run for this pull request reports a code coverage of \`${coverage}\`.`;
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ async function run() {
       badgeBranch: core.getInput('badge_branch') || 'badge-generator',
       mainBranch: core.getInput('main_branch') || 'main',
       githubToken: core.getInput('github_token'),
+      commentTitle: core.getInput('comment_title'),
     };
 
     const isPR = github.context.eventName === 'pull_request';
@@ -50,11 +51,17 @@ async function run() {
       if (pullRequests.length > 0) {
         const prNumber = pullRequests[0].number;
         core.info(`Found open PR #${prNumber} for branch ${currentBranch}. Commenting coverage...`);
-        await commentCoverageOnPR({
+        const commentOptions = {
           token: inputs.githubToken,
           coverage: inputs.name,
           prNumber,
-        });
+        };
+
+        if (inputs.commentTitle) {
+          commentOptions.commentTitle = inputs.commentTitle;
+        }
+
+        await commentCoverageOnPR(commentOptions);
       } else {
         core.info(`No open PR found for branch ${currentBranch}. Skipping comment.`);
       }


### PR DESCRIPTION

Adds an optional comment_title input so you can give each coverage comment its own title 

useful when the same workflow runs Vitest and Cypress separately and you want both comments to be clearly labeled instead of looking identical.

Default behavior is unchanged: if you don't set comment_title, the action keeps posting Code Coverage Result like before.

What changed:
- new optional comment_title input wired from action.yml through to PR comment generation
- falls back to the existing default title when the input is not provided
- tests for input forwarding and comment rendering
- README updated with a multi-coverage usage example
- action.schema.json now has descriptions for the existing inputs that were missing them
